### PR TITLE
Add docs & basic test

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,107 @@ s.inactive()
 
 // cancel an inactive call
 s.active()
-
-// release the handlers
-s.release()
 ```
+
+## API
+
+#### `const w = new Wakeup([onwakeup])`
+
+Create a new wakeup swarm with a `onwakeup` callback. `onwakeup` is called with the `id` and `stream` whenever a new peer connects. `id` is the wakeup topic (see `w.session()` for more info). `stream` is the Protomux instance.
+
+#### `w.topics`
+
+A map of all topics being tracked.
+
+#### `const sessions = w.getSessions(capability, handlers = {})`
+
+Return all sessions for the topic that matches the `capability` & `handlers`.
+
+#### `const s = w.session(capability, handlers = {})`
+
+Create a session to track the capability. Handlers includes hook callbacks for the life cycle of peers in the session.
+
+```
+const s = w.session(core.key, {
+  onpeeradd: (peer, session) => {
+    // Called when a peer is added to the session
+  },
+  onpeerremove: (peer, session) => {
+    // Called when a peer is removed from the session
+  },
+  onpeeractive: (peer, session) => {
+    // Called when a peer becomes active
+  },
+  onpeerinactive: (peer, session) => {
+    // Called when a peer becomes inactive
+  },
+  onannounce: (wakeup, peer, session) => {
+    // Called when a peer announces its available wake ups
+  },
+  onlookup: (req, peer, session) => {
+    // Called when a peer requests available wake ups
+  }
+})
+```
+
+`handlers` can also includes:
+
+```
+{
+  active: true, // Whether the session is currently active / replicating
+  discoveryKey: crypto.discoveryKey(capability) // The buffer to use as the `id` for the wake up topic. If not provide a discoveryKey hash of the capability will be used.
+}
+```
+
+#### `s.peers`
+
+Peers on the session's topic.
+
+#### `s.topic`
+
+The session's topic.
+
+#### `s.isActive`
+
+Whether the session is active.
+
+#### `s.addStream(stream)`
+
+Add the `stream` to the current session. If `stream` doesn't have a Protomux instance, one will added.
+
+#### `const peer = s.getPeer(stream)`
+
+Get the peer for the given `stream`.
+
+#### `s.lookup(peer, req = { hash: null })`
+
+Send a lookup request to a `peer`. `req` can be of the form `{ hash }`.
+
+Usually used to prompt the peer for any available wake ups.
+
+#### `s.broadcastLookup(req)`
+
+Call `s.lookup()` on all peers.
+
+#### `s.lookupByStream(stream, req)`
+
+A shortcut for calling `s.lookup()` on the peer for a given `stream`.
+
+#### `s.announce(peer, wakeup)`
+
+Announce to the peer an array of wake up messages. Wake up messages have the form `{ key: Buffer, length: Number }`. The `key` buffer is 32 bytes long.
+
+#### `s.announceByStream(stream, wakeup)`
+
+A shortcut for calling `s.announce()` on the peer for a given `stream`.
+
+#### `s.active()`
+
+Set the session as active. Sessions are active by default.
+
+#### `s.inactive()`
+
+Set the session as inactive. This must be called when the session is done.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "spec/hyperschema/*.js"
   ],
   "scripts": {
-    "test": "standard"
+    "test": "standard && brittle test/*.js"
   },
   "repository": {
     "type": "git",
@@ -27,6 +27,7 @@
   },
   "homepage": "https://github.com/holepunchto/protomux-wakeup",
   "devDependencies": {
+    "brittle": "^3.17.1",
     "standard": "^17.1.2"
   }
 }

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,0 +1,93 @@
+const test = require('brittle')
+const SecretStream = require('@hyperswarm/secret-stream')
+const crypto = require('hypercore-crypto')
+const Wakeup = require('../index')
+
+test('basic - onwakeup', (t) => {
+  t.plan(2)
+
+  const cap = Buffer.alloc(32).fill('stuffimcapableof')
+  const w1 = new Wakeup()
+
+  const w2 = new Wakeup(function onwakeup (id, mux) {
+    t.is(mux.stream, s2)
+    t.alike(id, crypto.discoveryKey(cap))
+  })
+
+  const s1 = new SecretStream(true)
+  const s2 = new SecretStream(false)
+
+  replicate(s1, s2)
+
+  w1.addStream(s1)
+  w2.addStream(s2)
+
+  const s = w1.session(cap)
+  s.active()
+})
+
+test('basic - session handler callbacks', async (t) => {
+  t.plan(7)
+
+  const cap = Buffer.alloc(32).fill('stuffimcapableof')
+  const key = Buffer.alloc(32).fill('deadbeef')
+  const length = 1337
+
+  const [w1, w2] = create()
+
+  const s1 = w1.session(cap, {
+    onpeeradd: (peer) => {
+      t.pass('onpeeradd called')
+    },
+    onannounce: (wakeup) => {
+      t.alike(wakeup, [{ key, length }], 'received wakeups')
+    }
+  })
+
+  w2.session(cap, {
+    onpeerremove: () => {
+      t.pass('onpeerremove called')
+    },
+    onpeeractive: () => {
+      t.pass('onpeeractive called')
+    },
+    onpeerinactive: () => {
+      t.pass('onpeerinactive called')
+    },
+    onlookup: (_, peer, session) => {
+      t.pass('onlookup called')
+      session.announce(peer, [{ key, length }])
+    }
+  })
+
+  await new Promise((resolve) => setImmediate(resolve))
+
+  s1.lookup(s1.peers[0])
+
+  await new Promise((resolve) => setImmediate(resolve))
+
+  s1.inactive()
+
+  s1.active()
+
+  s1.destroy()
+})
+
+function create () {
+  const w1 = new Wakeup()
+  const w2 = new Wakeup()
+
+  const s1 = new SecretStream(true)
+  const s2 = new SecretStream(false)
+
+  replicate(s1, s2)
+
+  w1.addStream(s1)
+  w2.addStream(s2)
+
+  return [w1, w2]
+}
+
+function replicate (a, b) {
+  a.rawStream.pipe(b.rawStream).pipe(a.rawStream)
+}


### PR DESCRIPTION
Documented most of the API leaving out `WakeupTopic` & `WakeupPeer`. Most usage that I've seen focuses on the sessions so opted to stop there.

Tests include:

- Basic test for using `onwakeup`
- A test that triggers all session handlers.