### PR TITLE
check GC on new session + Fix sessionsClosed metric

### DIFF
--- a/index.js
+++ b/index.js
@@ -450,6 +450,7 @@ class WakeupTopic {
     this.state._removeGC(this)
 
     for (let i = this.sessions.length - 1; i >= 0; i--) {
+      this.state.stats.sessionsClosed++
       const session = this.sessions[i]
       if (session.handlers.ondestroy) session.handlers.ondestroy(session)
     }

--- a/index.js
+++ b/index.js
@@ -365,6 +365,7 @@ class WakeupTopic {
     session.index = this.sessions.length
     this.sessions.push(session)
     this._bumpActivity()
+    this._checkGC()
     return session
   }
 


### PR DESCRIPTION
1) Existing code could open a new session on a topic that's queued for gc'ing, and still get gc'd later with an open session. We now check the gc-state whenever a new session is opened.

2) There are 2 paths for a session to get closed: by tearing down the topic, or by explicitly calling `topic.removeSession()`. We weren't counting those from the teardown, so the book keeping was off.

Note: we could consider refactoring the code to simplify the session lifecycle, so both flows go through a shared method